### PR TITLE
Add addressAlertsto property details

### DIFF
--- a/app/javascript/src/components/Property/AddressAlerts.js
+++ b/app/javascript/src/components/Property/AddressAlerts.js
@@ -1,0 +1,32 @@
+import React from 'react'
+
+const AddressAlerts = ({cautionaryAlerts}) => {
+
+  let alertsToShow = adrAlerts => {
+    if (adrAlerts.length != 0){
+
+      let alertsHtml = adrAlerts.map((alert, index) => {
+        return (
+          <li key={index}>
+            {alert.description} (
+            <span className='govuk-!-font-weight-bold'>{alert.alertCode}</span>)
+          </li>
+        )
+      })
+
+      return (
+        <ul className='govuk-tag bg-orange'>Address alerts: {alertsHtml}</ul>
+      )
+    } else {
+      return ""
+    }
+  }
+
+  return (
+    <>
+      <div className='hackney-property-alerts'>{alertsToShow(cautionaryAlerts)}</div>
+    </>
+  )
+}
+
+export default AddressAlerts

--- a/app/javascript/src/components/Property/PropertyDetails.js
+++ b/app/javascript/src/components/Property/PropertyDetails.js
@@ -1,6 +1,8 @@
 import React from 'react'
+import AddressAlerts from './AddressAlerts'
 
-const PropertyDetails = ({ propertyReference, address, hierarchyType }) => (
+const PropertyDetails = ({ propertyReference, address, hierarchyType, cautionaryAlerts }) => (
+
   <div>
     <h1 className="govuk-heading-l">
       {hierarchyType.subTypeDescription}: {address.addressLine}
@@ -8,7 +10,7 @@ const PropertyDetails = ({ propertyReference, address, hierarchyType }) => (
 
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-half">
-        <p className="govuk-body-s">
+        <div className="govuk-body-s">
           <span className="govuk-body-xs">
             Property details
           </span>
@@ -29,10 +31,11 @@ const PropertyDetails = ({ propertyReference, address, hierarchyType }) => (
             {address.postalCode}
           </span>
           <br></br>
-        </p>
+          <AddressAlerts cautionaryAlerts={cautionaryAlerts}/>
+        </div>
       </div>
     </div>
-   </div>
+  </div>
 )
 
 export default PropertyDetails

--- a/app/javascript/src/components/Property/PropertyDetails.test.js
+++ b/app/javascript/src/components/Property/PropertyDetails.test.js
@@ -16,15 +16,26 @@ describe('PropertyDetails component', () => {
         "levelCode": "7",
         "subTypeCode": "DWE",
         "subTypeDescription": "Dwelling"
+      },
+      "cautionaryAlerts": {
+        "propertyReference": "00012345",
+        "alerts": [{
+          "alertCode": "DIS",
+          "description": "Property Under Disrepair",
+          "startDate": "2011-02-16",
+          "endDate": null
+        }]
       }
     }
   }
 
   it('should render properly', () => {
+    
     const { asFragment } = render(<PropertyDetails
                                     propertyReference={props.property.propertyReference}
-                                    address={props.property.address}
                                     hierarchyType={props.property.hierarchyType}
+                                    address={props.property.address}
+                                    cautionaryAlerts={props.property.cautionaryAlerts.alerts}
                                   />)
     expect(asFragment()).toMatchSnapshot()
   })

--- a/app/javascript/src/components/Property/PropertyView.js
+++ b/app/javascript/src/components/Property/PropertyView.js
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react'
 import { getProperty } from '../../utils/api/properties'
+import { getAlerts } from '../../utils/api/cautionary_alerts'
 import PropertyDetails from './PropertyDetails'
 import Spinner from '../Spinner/Spinner'
 
-const PropertyView = (props) => {
+const PropertyView = props => {
   const [property, setProperty] = useState({})
+  const [addressAlerts, setaddressAlerts] = useState([])
   const [loading, setLoading] = useState(false)
 
-  const getPropertyView = async (propertyReference) => {
+  const getPropertyView = async propertyReference => {
     try {
       const data = await getProperty(propertyReference)
       setProperty(data)
@@ -19,11 +21,25 @@ const PropertyView = (props) => {
     setLoading(false)
   }
 
+  const getAlertsView = async propertyReference => {
+    try {
+      const data = await getAlerts(propertyReference)
+
+      setaddressAlerts(data.alerts || [])
+    } catch (e) {
+      setaddressAlerts([])
+      console.log('An error has occured:', e)
+    }
+
+    setLoading(false)
+  }
+
   useEffect(() => {
     setLoading(true)
     const propertyReference = props.match.params.propertyReference
 
     getPropertyView(propertyReference)
+    getAlertsView(propertyReference)
   }, [])
 
   return (
@@ -32,13 +48,14 @@ const PropertyView = (props) => {
         <Spinner />
       ) : (
         <>
-          {property && property.address && property.hierarchyType &&
+          {property && property.address && property.hierarchyType && (
             <PropertyDetails
               propertyReference={property.propertyReference}
               address={property.address}
+              cautionaryAlerts={addressAlerts}
               hierarchyType={property.hierarchyType}
             />
-          }
+          )}
         </>
       )}
     </>

--- a/app/javascript/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
+++ b/app/javascript/src/components/Property/__snapshots__/PropertyDetails.test.js.snap
@@ -14,7 +14,7 @@ exports[`PropertyDetails component should render properly 1`] = `
       <div
         class="govuk-grid-column-one-half"
       >
-        <p
+        <div
           class="govuk-body-s"
         >
           <span
@@ -41,7 +41,25 @@ exports[`PropertyDetails component should render properly 1`] = `
             E9 6PT
           </span>
           <br />
-        </p>
+          <div
+            class="hackney-property-alerts"
+          >
+            <ul
+              class="govuk-tag bg-orange"
+            >
+              Address alerts: 
+              <li>
+                Property Under Disrepair (
+                <span
+                  class="govuk-!-font-weight-bold"
+                >
+                  DIS
+                </span>
+                )
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/src/utils/api/cautionary_alerts.js
+++ b/app/javascript/src/utils/api/cautionary_alerts.js
@@ -1,0 +1,10 @@
+import axios from 'axios'
+
+const { ENDPOINT_API } = process.env
+
+export const getAlerts = async propertyReference => {
+  const { data } = await axios.get(
+    `${ENDPOINT_API}/properties/${propertyReference}/cautionary-alerts`
+  )
+  return data
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 $govuk-font-family: "GDS Transport" , arial, sans-serif !important;
+
 @import "govuk-frontend/govuk/all";
 
 @import "colours";
@@ -7,3 +8,4 @@ $govuk-font-family: "GDS Transport" , arial, sans-serif !important;
 
 @import "components/button";
 @import "components/header";
+@import "components/property-details";

--- a/app/javascript/stylesheets/colours.scss
+++ b/app/javascript/stylesheets/colours.scss
@@ -1,7 +1,8 @@
 $repairs-hub-colours: (
   "housing-1": #005f61,
   "housing-2": #009ca6,
-  "housing-3": #2dccd3
+  "housing-3": #2dccd3,
+  "bg-orange": #FFA300
 );
 
 @function repairs-hub-colour($colour) {

--- a/app/javascript/stylesheets/components/property-details.scss
+++ b/app/javascript/stylesheets/components/property-details.scss
@@ -1,0 +1,16 @@
+.hackney-property-alerts {
+  width: 60%;
+  padding: 0;
+
+  li {
+    font-family: Arial, Helvetica, sans-serif !important;
+    text-transform: capitalize;
+    margin-bottom: 5px;
+    padding: 4px 8px;
+    font-weight: normal;
+  }
+}
+
+.bg-orange {
+  background-color: repairs-hub-colour('bg-orange') !important;
+}


### PR DESCRIPTION
### Description of change

Show address alerts on property description
Implement styling to address alerts field

### Story Link

https://trello.com/c/No3ca2yv/168-as-a-user-i-need-to-see-cautionary-alerts-on-the-property-so-that-i-can-keep-our-operatives-safe



### How to test

To be able to test this branch you need to pull this PR from repairs-api :
https://github.com/LBHackney-IT/repairs-api/pull/14/files
and run it locally as back end 


If property doesn't have alerts:

![Screenshot 2020-11-27 at 13 48 24](https://user-images.githubusercontent.com/51852726/100455821-4635a000-30b7-11eb-964f-3e4dbd8e3f09.png)

If property has alerts:

![Screenshot 2020-12-01 at 15 57 02](https://user-images.githubusercontent.com/51852726/100764091-e0665280-33ed-11eb-80ad-da0edd12883a.png)


